### PR TITLE
docs+fix: 기본 포트 8000→8100 전파 + README 이슈 추적성 강화

### DIFF
--- a/DEPLOY_v9.md
+++ b/DEPLOY_v9.md
@@ -3,6 +3,37 @@
 v8 이후 운영 중 발견된 **CPU-only 환경에서의 OOM 크래시** 문제를 해결하기 위해 도입된
 변경 사항과 배포 절차.
 
+## ⚠️ 운영 변경점 — 기본 포트 8000 → 8100 (이슈 #2)
+
+v9 부터 컨테이너의 기본 서비스 포트가 **8100** 으로 바뀝니다. 사내에서 8000 번이
+이미 다른 서비스들과 충돌이 잦다는 이슈([#2](https://github.com/MustangYun/paper_slice/issues/2))
+반영. 컨테이너 내부 포트도 8100 으로 통일해 호스트/컨테이너 불일치 혼선을 제거했습니다.
+
+| 층위 | v8 | v9 |
+|---|---|---|
+| 컨테이너 내부 (uvicorn --port) | 8000 | **8100** |
+| Dockerfile `EXPOSE` / HEALTHCHECK URL | 8000 | **8100** |
+| docker-compose.yml 호스트 매핑 | `${PAPERSLICE_PORT:-8000}:8000` | **`${PAPERSLICE_PORT:-8100}:8100`** |
+| scripts/run_local.{sh,ps1} 기본 포트 | 8000 | **8100** |
+
+### 마이그레이션 — 기존 8000 을 유지해야 하는 경우
+호스트 쪽만 8000 으로 노출하는 env override:
+```bash
+PAPERSLICE_PORT=8000 docker compose up
+```
+이 경우에도 컨테이너 내부는 8100 이므로, 컨테이너에 직접 접근하는 클라이언트가
+있다면 8100 으로 가야 합니다. reverse proxy (nginx / Traefik) 뒤라면 upstream URL
+만 8100 으로 바꾸면 됩니다.
+
+### 전환 체크리스트
+- [ ] `docker compose down` 으로 기존 v8 컨테이너 중지
+- [ ] 본 가이드대로 v9 소스 반영 후 `docker compose build --no-cache`
+- [ ] `curl http://localhost:8100/health` 로 새 포트 동작 확인
+- [ ] 클라이언트/모니터링의 `:8000` hard-coded URL 확인 및 8100 으로 변경 (또는 위 env override)
+- [ ] K8s / CI/CD 파이프라인의 containerPort / targetPort 값을 8100 으로 갱신
+
+---
+
 ## 왜 v9 인가 — 해결한 4가지 근본 원인
 
 v8 기준으로 119 페이지 PDF(이슈 #3)는 `mineru-api` 워커가 OOM killer 에 맞아 죽으며
@@ -94,7 +125,7 @@ docker compose up -d
 docker compose logs paperslice | grep -E "CPU tuning|Uvicorn running"
 # 기대 출력 예:
 #   paperslice | INFO [paperslice.cpu_tuning] CPU tuning: threads=4 (source=cgroup_v2, cpu_count=8)
-#   paperslice | INFO:     Uvicorn running on http://0.0.0.0:8000
+#   paperslice | INFO:     Uvicorn running on http://0.0.0.0:8100
 ```
 
 ### Windows (PowerShell)
@@ -162,7 +193,7 @@ docker exec $(docker compose ps -q paperslice) env | grep -E "^(OMP|MKL|OPENBLAS
 ### 페이지 청킹이 도는지 (10 페이지 초과 PDF)
 
 ```bash
-curl -s -X POST http://localhost:8000/parse \
+curl -s -X POST http://localhost:8100/parse \
   -F "file=@big_sample_119p.pdf" \
   -F "language=korean" -F "mode=auto" -o /dev/null
 
@@ -177,7 +208,7 @@ docker compose logs paperslice | grep -E "MinerU chunk|chunk 결과 병합"
 ### 10 페이지 이하 PDF 는 청킹이 스킵되는지
 
 ```bash
-curl -s -X POST http://localhost:8000/parse \
+curl -s -X POST http://localhost:8100/parse \
   -F "file=@small_8p.pdf" -o /dev/null
 
 docker compose logs paperslice | grep -E "\[2/8\]" | tail -2
@@ -208,7 +239,7 @@ pytest -v
 
 ### 16 GB / 8 vCPU 박스 (throughput 중심)
 ```bash
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   --cpus=8 --memory=16g \
   -e PAPERSLICE_CPU_THREADS=6 \
   -e PAPERSLICE_MINERU_VIRTUAL_VRAM_GB=2 \
@@ -218,7 +249,7 @@ docker run --rm -p 8000:8000 \
 
 ### 4 GB / 2 vCPU 극소형 박스
 ```bash
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   --cpus=2 --memory=4g \
   -e PAPERSLICE_CPU_THREADS=2 \
   -e PAPERSLICE_CHUNK_PAGES=3 \
@@ -230,7 +261,7 @@ docker run --rm -p 8000:8000 \
 ### GPU 박스로 돌릴 때 (v9 기능 비활성화)
 CPU 튜닝 / 청킹 은 GPU 에서도 무해하지만, 필요 시 비활성화:
 ```bash
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   --gpus all \
   -e PAPERSLICE_DEFAULT_BACKEND=vlm \
   -e PAPERSLICE_MINERU_DEVICE_MODE=cuda \

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,9 +97,11 @@ RUN useradd --create-home --home-dir /home/paperslice --shell /usr/sbin/nologin 
     chown -R paperslice:paperslice /app /home/paperslice /tmp/paperslice-scratch
 
 USER paperslice
-EXPOSE 8000
+# v9: 기본 포트 8000 → 8100 (이슈 #2). 컨테이너 내부는 8100 고정,
+# 호스트 매핑은 docker-compose.yml 의 PAPERSLICE_PORT env 로 조정.
+EXPOSE 8100
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
-    CMD curl -fsS http://127.0.0.1:8000/health || exit 1
+    CMD curl -fsS http://127.0.0.1:8100/health || exit 1
 
-CMD ["uvicorn", "paperslice.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "paperslice.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
 ### 주요 기능
 - **다국어 OCR** — 한국어 / 일본어 / 중국어(간·번체) / 영어 등 PaddleOCR이 지원하는 언어 전부.
 - **세로쓰기 자동 감지 (v8)** — PyMuPDF로 PDF를 먼저 살펴 세로쓰기·스캔본이면 자동으로 OCR 경로로 분기.
-- **CPU 자동 튜닝 (v9)** — 컨테이너 기동 시 cgroup / CPU affinity 를 탐지해 OMP/MKL/OpenBLAS/torch 스레드를 [2, 8] 로 자동 캡. vCPU 폭주로 인한 메모리 터짐 방지.
-- **페이지 단위 청킹 (v9)** — 큰 PDF(기본 10페이지 초과)를 5페이지 단위로 쪼개 MinerU 를 여러 번 호출. 한 호출의 피크 메모리가 chunk 크기에 비례해 내려가 **CPU-only 8GB 박스에서도 119페이지 PDF 완주** 가능.
-- **OOM 자동 재시도 (v9)** — MinerU stderr 에서 `OutOfMemoryError` / `Killed` / `RemoteDisconnected` / `ConnectionReset` 등이 감지되면 `MINERU_VIRTUAL_VRAM_SIZE` 를 반감해 재시도.
+- **CPU 자동 튜닝 (v9, [이슈 #3](https://github.com/MustangYun/paper_slice/issues/3) / [#4](https://github.com/MustangYun/paper_slice/issues/4))** — 컨테이너 기동 시 cgroup / CPU affinity 를 탐지해 OMP/MKL/OpenBLAS/torch 스레드를 [2, 8] 로 자동 캡. vCPU 폭주로 인한 메모리 터짐 방지.
+- **페이지 단위 청킹 (v9, [이슈 #3](https://github.com/MustangYun/paper_slice/issues/3) / [#4](https://github.com/MustangYun/paper_slice/issues/4))** — 큰 PDF(기본 10페이지 초과)를 5페이지 단위로 쪼개 MinerU 를 여러 번 호출. 한 호출의 피크 메모리가 chunk 크기에 비례해 내려가 **CPU-only 8GB 박스에서도 119페이지 PDF 완주** 가능.
+- **OOM 자동 재시도 (v9, [이슈 #3](https://github.com/MustangYun/paper_slice/issues/3))** — MinerU stderr 에서 `OutOfMemoryError` / `Killed` / `RemoteDisconnected` / `ConnectionReset` 등이 감지되면 `MINERU_VIRTUAL_VRAM_SIZE` 를 반감해 재시도.
+- **MinerU 모델 프리베이크 (v9, [이슈 #1](https://github.com/MustangYun/paper_slice/issues/1))** — Docker 빌드 중 pipeline 모델을 이미지에 구워 넣어 첫 요청의 수 GB 다운로드를 제거. 폐쇄망 빌드면 `|| echo WARNING` 으로 빌드 자체는 성공.
+- **기본 포트 8100 (v9, [이슈 #2](https://github.com/MustangYun/paper_slice/issues/2))** — 사내망에서 흔히 충돌하던 8000 대신 8100 을 기본으로. `PAPERSLICE_PORT=8000` 으로 구버전 호환 가능.
 - **기사 단위 세그멘테이션** — column 검출 후 헤드라인-본문-이미지를 한 노드로 묶음.
 - **Provenance 보존** — 모든 텍스트 블록과 이미지에 원본 페이지 번호와 bbox가 그대로 붙음.
 - **이미지 자산 관리** — 추출된 이미지를 `output/<document_id>/images/` 에 영구 저장 + 다운로드 API.
@@ -32,9 +34,11 @@
 - **Cross-platform Docker** — macOS / Linux / Windows에서 동일한 `docker compose up --build`.
 
 ### 이 브랜치 (`claude/cross-platform-docker-fi22j`) 에서 한 것
-원본 v8은 Windows에서만 검증되어 있었습니다. 이 브랜치는 소스 변경 없이 빌드·실행·
-문서를 손봐 **macOS / Linux / Windows 동일 명령어로 돌아가게** 만든 판입니다
+원본 v8은 Windows에서만 검증되어 있었습니다. 이 브랜치는 빌드·실행·문서를 손봐
+**macOS / Linux / Windows 동일 명령어로 돌아가게** 만든 판입니다
 (`.gitattributes` 라인엔딩 정규화, bash/PowerShell 스크립트 페어, Apple Silicon 자동 `--platform=linux/amd64`, 상대경로 `docker-compose.yml` 등).
+v9 업데이트가 같이 머지되면서 **CPU 자동 튜닝 · 페이지 청킹 · 모델 프리베이크 · 기본 포트 8100**
+도 여기에 포함돼 있습니다 — [주요 기능](#주요-기능) / [CPU 전용 운영 가이드 (v9)](#cpu-전용-운영-가이드-v9) 참고.
 
 ---
 
@@ -42,7 +46,8 @@
 
 ### 공통 전제
 - Docker Desktop (Windows/macOS) 또는 Docker Engine (Linux)
-- 8000 포트 사용 가능
+- **8100 포트 사용 가능** *(v9 에서 기본값이 8000 → 8100 으로 변경, [이슈 #2](https://github.com/MustangYun/paper_slice/issues/2))*
+  - 구버전 호환이 필요하면 `PAPERSLICE_PORT=8000 docker compose up` 으로 호스트 쪽만 8000 으로 노출 가능 (컨테이너 내부는 8100 고정).
 
 ### macOS / Linux
 
@@ -53,7 +58,7 @@ cd paper_slice
 
 # 빌드 + 실행 (가장 간단)
 docker compose up --build
-# → http://localhost:8000/docs 로 접속
+# → http://localhost:8100/docs 로 접속
 ```
 
 스크립트를 직접 쓰고 싶다면:
@@ -197,6 +202,7 @@ MinerU가 그대로 PaddleOCR에 전달하는 언어 코드.
 | `PAPERSLICE_OUTPUT_ROOT` | `/app/output` | 컨테이너 내부의 영구 출력 경로. 보통 볼륨 마운트. |
 | `PAPERSLICE_SCRATCH_ROOT` | `/tmp/paperslice-scratch` | 요청별 임시 작업 디렉터리. 끝나면 삭제. |
 | `PAPERSLICE_MAX_UPLOAD_MB` | `100` | PDF 업로드 최대 크기. |
+| `PAPERSLICE_PORT` | `8100` | **v9 변경** ([이슈 #2](https://github.com/MustangYun/paper_slice/issues/2)): 기본 서비스 포트 (이전 8000). `docker-compose.yml` 의 호스트→컨테이너 매핑에 사용. 컨테이너 내부는 8100 고정이므로 `PAPERSLICE_PORT=8000 docker compose up` 으로 호스트만 8000 으로 노출 가능. |
 | `PAPERSLICE_MINERU_TIMEOUT_SEC` | `1800` | MinerU 1회 실행 타임아웃 (초). 첫 실행 시 모델 다운로드가 있어서 길게 잡음. |
 | `PAPERSLICE_CORS_ALLOW_ORIGINS` | `["*"]` | CORS allowed origins. 운영 환경에서는 프론트 도메인으로 좁히세요. |
 | `PAPERSLICE_MINERU_BIN` | `mineru` | MinerU CLI 바이너리 경로. |
@@ -223,14 +229,14 @@ MinerU가 그대로 PaddleOCR에 전달하는 언어 코드.
 예:
 ```bash
 # 사용량이 적은 공유 서버에서 타임아웃 줄이고 업로드 제한 올리기
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   -e PAPERSLICE_MAX_UPLOAD_MB=200 \
   -e PAPERSLICE_MINERU_TIMEOUT_SEC=600 \
   -e PAPERSLICE_STRICT_GPU=true \
   paperslice:latest
 
 # 16GB RAM / 8 vCPU 박스에서 throughput 올리기 (v9)
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   --cpus=8 --memory=16g \
   -e PAPERSLICE_CPU_THREADS=6 \
   -e PAPERSLICE_MINERU_VIRTUAL_VRAM_GB=2 \
@@ -238,7 +244,7 @@ docker run --rm -p 8000:8000 \
   paperslice:latest
 
 # 4GB 초저메모리 박스에서 안정화 — chunk 더 작게, vram 더 낮게
-docker run --rm -p 8000:8000 \
+docker run --rm -p 8100:8100 \
   --cpus=2 --memory=4g \
   -e PAPERSLICE_CPU_THREADS=2 \
   -e PAPERSLICE_MINERU_VIRTUAL_VRAM_GB=1 \
@@ -390,13 +396,13 @@ docker compose up --build
 ```
 성공 로그:
 ```
-paperslice  | INFO:     Uvicorn running on http://0.0.0.0:8000
+paperslice  | INFO:     Uvicorn running on http://0.0.0.0:8100
 paperslice  | INFO:     Application startup complete.
 ```
 
 ### 2) `/docs` (Swagger UI)에서 인터랙티브 테스트
 
-브라우저로 **http://localhost:8000/docs** 열기.
+브라우저로 **http://localhost:8100/docs** 열기.
 
 1. `POST /parse` 패널을 클릭 → **Try it out**
 2. `file` 슬롯에 PDF 파일 업로드 (드래그 또는 Choose File)
@@ -416,19 +422,19 @@ paperslice  | INFO:     Application startup complete.
 
 ```bash
 # 헬스 체크
-curl -s http://localhost:8000/health
+curl -s http://localhost:8100/health
 # → {"status":"ok"}
 
 # 런타임 정보
-curl -s http://localhost:8000/info | python3 -m json.tool
+curl -s http://localhost:8100/info | python3 -m json.tool
 
 # PDF 파싱 (가장 기본)
-curl -s -X POST http://localhost:8000/parse \
+curl -s -X POST http://localhost:8100/parse \
   -F "file=@/path/to/sample.pdf" \
   | python3 -m json.tool > result.json
 
 # 일본 신문 PDF, 세로쓰기, auto 모드
-curl -s -X POST http://localhost:8000/parse \
+curl -s -X POST http://localhost:8100/parse \
   -F "file=@/path/to/nikkan.pdf" \
   -F "language=japan" \
   -F "reading_direction=rtl" \
@@ -436,7 +442,7 @@ curl -s -X POST http://localhost:8000/parse \
   | python3 -m json.tool > nikkan_result.json
 
 # 한국어 논문, txt 강제, diff 리포트 포함
-curl -s -X POST http://localhost:8000/parse \
+curl -s -X POST http://localhost:8100/parse \
   -F "file=@/path/to/paper.pdf" \
   -F "language=korean" \
   -F "mode=txt" \
@@ -444,16 +450,16 @@ curl -s -X POST http://localhost:8000/parse \
   | python3 -m json.tool > paper_result.json
 
 # 파싱 결과에서 document_id만 뽑기
-DOC_ID=$(curl -s -X POST http://localhost:8000/parse \
+DOC_ID=$(curl -s -X POST http://localhost:8100/parse \
   -F "file=@sample.pdf" | python3 -c "import sys,json;print(json.load(sys.stdin)['document_id'])")
 echo "document_id=$DOC_ID"
 
 # 특정 페이지의 raw MinerU 블록 보기
-curl -s "http://localhost:8000/documents/$DOC_ID/pages/1/blocks" \
+curl -s "http://localhost:8100/documents/$DOC_ID/pages/1/blocks" \
   | python3 -m json.tool
 
 # 그 문서의 raw artifact 목록
-curl -s "http://localhost:8000/documents/$DOC_ID/raw" | python3 -m json.tool
+curl -s "http://localhost:8100/documents/$DOC_ID/raw" | python3 -m json.tool
 ```
 
 #### Windows PowerShell
@@ -462,10 +468,10 @@ curl -s "http://localhost:8000/documents/$DOC_ID/raw" | python3 -m json.tool
 
 ```powershell
 # 헬스 체크
-curl.exe -s http://localhost:8000/health
+curl.exe -s http://localhost:8100/health
 
 # PDF 파싱
-curl.exe -s -X POST http://localhost:8000/parse `
+curl.exe -s -X POST http://localhost:8100/parse `
   -F "file=@C:\Users\User-1\Documents\sample.pdf" `
   -F "language=japan" `
   -F "reading_direction=rtl" `
@@ -478,14 +484,14 @@ Get-Content result.json | ConvertFrom-Json | ConvertTo-Json -Depth 10
 
 ```powershell
 # 헬스
-Invoke-RestMethod http://localhost:8000/health
+Invoke-RestMethod http://localhost:8100/health
 
 # 런타임 정보
-Invoke-RestMethod http://localhost:8000/info | ConvertTo-Json -Depth 5
+Invoke-RestMethod http://localhost:8100/info | ConvertTo-Json -Depth 5
 
 # PDF 파싱 (PS 7.0+에서 -Form 지원)
 $response = Invoke-RestMethod `
-    -Uri http://localhost:8000/parse `
+    -Uri http://localhost:8100/parse `
     -Method POST `
     -Form @{
         file              = Get-Item C:\Users\User-1\Documents\sample.pdf
@@ -498,7 +504,7 @@ Write-Host "document_id = $($response.document_id)"
 
 # 특정 페이지 블록
 $docId = $response.document_id
-Invoke-RestMethod "http://localhost:8000/documents/$docId/pages/1/blocks" `
+Invoke-RestMethod "http://localhost:8100/documents/$docId/pages/1/blocks" `
   | ConvertTo-Json -Depth 10
 ```
 
@@ -506,10 +512,10 @@ Invoke-RestMethod "http://localhost:8000/documents/$docId/pages/1/blocks" `
 
 ```cmd
 :: 헬스
-curl -s http://localhost:8000/health
+curl -s http://localhost:8100/health
 
 :: PDF 파싱 (CMD는 줄바꿈 이어쓰기 ^)
-curl -s -X POST http://localhost:8000/parse ^
+curl -s -X POST http://localhost:8100/parse ^
   -F "file=@C:\Users\User-1\Documents\sample.pdf" ^
   -F "language=japan" ^
   -F "reading_direction=rtl" ^
@@ -551,7 +557,7 @@ type result.json
 }
 ```
 
-자세한 필드 정의는 [`/docs`](http://localhost:8000/docs) 또는 `src/paperslice/schemas.py` 참조.
+자세한 필드 정의는 [`/docs`](http://localhost:8100/docs) 또는 `src/paperslice/schemas.py` 참조.
 
 ### 5) 실행 상태 확인 & 정리
 
@@ -602,7 +608,7 @@ pytest -v
 
 ```bash
 # 1) /info 에 v9 전용 필드가 보이면 성공
-curl -s http://localhost:8000/info | python3 -m json.tool
+curl -s http://localhost:8100/info | python3 -m json.tool
 # 기대 출력 (발췌):
 #   "cpu_tuning": { "threads": 4, "source": "affinity", "raw_cpu_count": 4 },
 #   "mineru_config": {
@@ -614,7 +620,7 @@ docker compose logs paperslice | grep "CPU tuning"
 # → CPU tuning: threads=4 (source=cgroup_v2, cpu_count=16)
 
 # 3) /docs 상단 설명에 "### v9 변경 (CPU 최적화)" 블록이 보이면 성공
-open http://localhost:8000/docs   # macOS
+open http://localhost:8100/docs   # macOS
 ```
 
 세 가지 중 하나라도 안 보이면 이미지/컨테이너가 구버전입니다.
@@ -685,7 +691,7 @@ open http://localhost:8000/docs   # macOS
 
 디버깅에 도움이 되는 엔드포인트:
 ```bash
-curl -s http://localhost:8000/info
+curl -s http://localhost:8100/info
 # → {"gpu_available": false, ...}
 
 docker compose logs paperslice 2>&1 | grep -E "CPU tuning|MinerU attempt|chunk"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ services:
         WITH_CORP_CA: ${WITH_CORP_CA:-0}
     image: paperslice:latest
     container_name: paperslice
+    # v9: 기본 호스트 포트 8000 → 8100 (이슈 #2). 구버전 호환이 필요하면
+    # `PAPERSLICE_PORT=8000 docker compose up` 으로 호스트 쪽만 8000 으로 노출.
     ports:
-      - "${PAPERSLICE_PORT:-8000}:8000"
+      - "${PAPERSLICE_PORT:-8100}:8100"
     volumes:
       - ./output:/app/output
     environment:
@@ -28,7 +30,7 @@ services:
       PAPERSLICE_SCRATCH_ROOT: /tmp/paperslice-scratch
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/health"]
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8100/health"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 : "${PAPERSLICE_HOST:=0.0.0.0}"
-: "${PAPERSLICE_PORT:=8000}"
+# v9: 기본 포트 8000 → 8100 (이슈 #2).
+: "${PAPERSLICE_PORT:=8100}"
 
 exec uvicorn paperslice.main:app \
   --host "$PAPERSLICE_HOST" \

--- a/scripts/run_local.ps1
+++ b/scripts/run_local.ps1
@@ -1,13 +1,15 @@
 # Run paperslice locally on Windows (PowerShell).
 #
 # Usage:
-#   .\scripts\run_local.ps1
-#   .\scripts\run_local.ps1 -Port 9000
+#   .\scripts\run_local.ps1                                  # 기본 포트 8100
+#   .\scripts\run_local.ps1 -Port 9000                       # 포트 변경
+#   .\scripts\run_local.ps1 -Port 8000                       # v8 구버전 호환 (호스트만 8000)
 #   .\scripts\run_local.ps1 -Tag paperslice:gpu -Extra "--gpus","all"
 [CmdletBinding()]
 param(
     [string]$Tag = "paperslice:latest",
-    [int]$Port = 8000,
+    # v9: 컨테이너 내부 포트 8000 → 8100 (이슈 #2). 호스트 측은 -Port 로 override.
+    [int]$Port = 8100,
     [string]$OutputDir = "",
     [string[]]$Extra = @()
 )
@@ -21,11 +23,11 @@ New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 $outputMount = ($OutputDir -replace '\\', '/')
 
 Write-Host "[run_local.ps1] Image : $Tag"
-Write-Host "[run_local.ps1] Port  : $Port -> 8000"
+Write-Host "[run_local.ps1] Port  : $Port -> 8100"
 Write-Host "[run_local.ps1] Output: $outputMount -> /app/output"
 
 $args = @("run", "--rm",
-          "-p", "$($Port):8000",
+          "-p", "$($Port):8100",
           "-v", "$($outputMount):/app/output") + $Extra + @($Tag)
 
 docker @args

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -2,14 +2,16 @@
 # Run paperslice locally on macOS / Linux.
 #
 # Usage:
-#   scripts/run_local.sh                  # port 8000, ./output 마운트
+#   scripts/run_local.sh                  # port 8100, ./output 마운트
 #   PORT=9000 scripts/run_local.sh        # 포트 변경
+#   PORT=8000 scripts/run_local.sh        # v8 구버전 호환 (호스트만 8000 으로 노출)
 #   IMAGE_TAG=paperslice:gpu scripts/run_local.sh --gpus all
 
 set -euo pipefail
 
 IMAGE_TAG="${IMAGE_TAG:-paperslice:latest}"
-PORT="${PORT:-8000}"
+# v9: 컨테이너 내부 포트 8000 → 8100 (이슈 #2). 호스트 포트는 PORT env 로 override.
+PORT="${PORT:-8100}"
 OUTPUT_DIR="${OUTPUT_DIR:-$(pwd)/output}"
 
 mkdir -p "$OUTPUT_DIR"
@@ -18,11 +20,11 @@ mkdir -p "$OUTPUT_DIR"
 EXTRA_ARGS=("$@")
 
 echo "[run_local.sh] Image : $IMAGE_TAG"
-echo "[run_local.sh] Port  : $PORT -> 8000"
+echo "[run_local.sh] Port  : $PORT -> 8100"
 echo "[run_local.sh] Output: $OUTPUT_DIR -> /app/output"
 
 docker run --rm \
-  -p "${PORT}:8000" \
+  -p "${PORT}:8100" \
   -v "${OUTPUT_DIR}:/app/output" \
   "${EXTRA_ARGS[@]}" \
   "$IMAGE_TAG"

--- a/src/paperslice/config.py
+++ b/src/paperslice/config.py
@@ -69,7 +69,15 @@ class Settings(BaseSettings):
 
     # --- Server ---
     host: str = Field(default="0.0.0.0")
-    port: int = Field(default=8000)
+    port: int = Field(
+        default=8100,
+        description=(
+            "기본 서비스 포트. v9 에서 8000 → 8100 으로 변경 (이슈 #2). "
+            "docker compose 의 호스트 측 매핑에 사용. 컨테이너 내부는 8100 고정. "
+            "구버전 호환이 필요하면 `PAPERSLICE_PORT=8000 docker compose up` 으로 "
+            "호스트 쪽만 8000 으로 노출 가능."
+        ),
+    )
     cors_allow_origins: list[str] = Field(
         default_factory=lambda: ["*"],
         description="CORS allowed origins. Set to your frontend domain in prod.",


### PR DESCRIPTION
## 배경

이슈 #1~#4 와 PR #5 를 전부 훑은 결과, **PR #5 가 머지되면서 v9 코드(청킹·CPU 튜닝·모델 프리베이크)는 main 에 다 들어갔지만, 이슈 #2(포트 8000→8100) 해결만 [`claude/optimize-cpu-performance-AiMcN` 커밋 051504b](https://github.com/MustangYun/paper_slice/commit/051504b01c0ece8843803b182cc716d596a60b6f) 에 남은 채 main 에 흡수되지 않은 상태**였습니다. 이 PR 은 그 누락을 복구하고, 이번 기회에 README 가 이슈 #1~#4 해결 이력을 명확하게 추적하도록 손봅니다.

## Summary

- **이슈 #2 해결 반영** — 코드 6개 파일 + 문서 2개에서 기본 포트 8000 → 8100 으로 전파. 구버전 호환은 `PAPERSLICE_PORT=8000 docker compose up` 로 호스트 매핑만 override.
- **README 이슈 뱃지** — 상단 "주요 기능" 리스트의 v9 피쳐에 해결한 이슈 번호 링크 추가. 모델 프리베이크(이슈 #1) / 기본 포트 8100(이슈 #2) 도 피쳐로 노출.
- **"이 브랜치에서 한 것" 블록 갱신** — cross-platform Docker 이야기만 하던 것에서 v9 머지 사실(CPU 튜닝·청킹·프리베이크·포트)을 한 줄로 명시.
- **DEPLOY_v9.md 맨 앞에 포트 변경 섹션** — v8↔v9 비교표 + 마이그레이션 체크리스트.

## 변경 파일 (8개)

### 코드
| 파일 | 변경 |
|---|---|
| `src/paperslice/config.py` | `port` 기본값 8100 + docstring 보강 |
| `Dockerfile` | `EXPOSE 8100`, HEALTHCHECK URL, `uvicorn --port 8100` |
| `docker-compose.yml` | `${PAPERSLICE_PORT:-8100}:8100`, healthcheck 8100 |
| `docker/entrypoint.sh` | `PAPERSLICE_PORT` 기본 8100 |
| `scripts/run_local.sh` / `.ps1` | 호스트/컨테이너 매핑 8100, 사용법 주석 갱신 |

### 문서
| 파일 | 변경 |
|---|---|
| `README.md` | 빠른 시작 "공통 전제", 모든 curl / Invoke-RestMethod / cmd 예시(29개 URL), 환경변수 표에 `PAPERSLICE_PORT` 행, 성공 로그, 이슈 뱃지 |
| `DEPLOY_v9.md` | "⚠️ 운영 변경점 — 기본 포트 8000 → 8100" 섹션 추가, 검증/예시 커맨드 전부 8100 으로 교체 |

## Test plan

- [ ] `docker compose up --build` → 기동 로그에 `Uvicorn running on http://0.0.0.0:8100` 확인
- [ ] `curl http://localhost:8100/health` → `{"status":"ok"}`
- [ ] `curl http://localhost:8100/info` → `cpu_tuning` / `mineru_config` 블록 노출 (v9 검증)
- [ ] 구버전 호환 테스트: `PAPERSLICE_PORT=8000 docker compose up` → `curl http://localhost:8000/health` 가 응답
- [ ] `grep -rn "localhost:8000\|-p 8000:8000\|0.0.0.0:8000" .` → 결과 없음 (맥락 설명 텍스트 외)
- [ ] `pytest -v` → 30 passed 유지

## 참고

- 이슈 #1 / #3 / #4 는 PR #5 (커밋 a2245b) 에서 이미 코드/Docker 레벨로 해결됨 — 이 PR 은 README 가시성 강화 성격.
- 이슈 #2 는 `claude/optimize-cpu-performance-AiMcN` 에 머물던 051504b 의 의도를 이 PR 로 main-line 에 재부착.

Closes #2

https://claude.ai/code/session_016WJhajhLoqzc2piqpb8xEi

---
_Generated by [Claude Code](https://claude.ai/code/session_016WJhajhLoqzc2piqpb8xEi)_