### PR TITLE
fix: mypy latent type-bugs (segmenter dataclass + BlockRole.index shadow)

### DIFF
--- a/src/paperslice/classifier.py
+++ b/src/paperslice/classifier.py
@@ -34,7 +34,11 @@ class BlockRole(str, Enum):
     ad_text = "ad_text"  # text block that is part of an advertisement
     page_header = "page_header"  # masthead, folio, page number
     page_footer = "page_footer"  # copyright line, etc.
-    index = "index"  # table-of-contents / "what's on other pages" listing
+    # value "index" 로 유지하여 직렬화/API 호환성 보존. python 이름을
+    # `toc_index` 로 바꾼 이유: BlockRole 은 str 상속이라 `index` 가 str.index
+    # 메서드를 shadowing 함. `role.index("x")` 호출 시 method 가 아닌 enum
+    # member 가 반환돼 AttributeError 소지.
+    toc_index = "index"  # table-of-contents / "what's on other pages" listing
     image = "image"
     table = "table"
     unknown = "unknown"
@@ -201,7 +205,7 @@ def classify_block(block: EnrichedBlock) -> ClassifiedBlock:
     # heuristic's phone-number regex).
     is_index, index_conf = _looks_like_index(text)
     if is_index:
-        return ClassifiedBlock(block, BlockRole.index, confidence=index_conf)
+        return ClassifiedBlock(block, BlockRole.toc_index, confidence=index_conf)
 
     # Ad-like text
     is_ad, ad_conf = _looks_like_ad(text)

--- a/src/paperslice/segmenter.py
+++ b/src/paperslice/segmenter.py
@@ -34,7 +34,7 @@ Future improvements (left as hooks):
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .block_enricher import EnrichedBlock
 from .classifier import BlockRole, ClassifiedBlock
@@ -64,21 +64,22 @@ _KIND_ALIAS = {
 
 @dataclass
 class _ArticleBuilder:
-    """Mutable scratch state while accumulating blocks into an article."""
+    """Mutable scratch state while accumulating blocks into an article.
+
+    list 필드들은 `field(default_factory=list)` 로 초기화. 이전엔 기본값이
+    `None` 이고 `__post_init__` 에서 빈 리스트로 치환하는 패턴이었는데,
+    (1) 타입이 선언(`list[X]`)과 실제 기본값(`None`) 이 어긋나고
+    (2) 누군가 builder 를 수동으로 만들고 `__post_init__` 우회할 경로가 생기면
+    `None.append()` 로 크래시.
+    """
 
     kind: NodeKind
     headline: TextNode | None = None
-    body_blocks: list[TextNode] = None
-    images: list[ImageNode] = None
-    bboxes: list[BoundingBox] = None
+    body_blocks: list[TextNode] = field(default_factory=list)
+    images: list[ImageNode] = field(default_factory=list)
+    bboxes: list[BoundingBox] = field(default_factory=list)
     confidence: float = 1.0
-    block_ids: list[str] = None
-
-    def __post_init__(self) -> None:
-        self.body_blocks = self.body_blocks or []
-        self.images = self.images or []
-        self.bboxes = self.bboxes or []
-        self.block_ids = self.block_ids or []
+    block_ids: list[str] = field(default_factory=list)
 
     def to_node(self, node_id: str) -> ArticleNode:
         return ArticleNode(
@@ -545,7 +546,7 @@ def _process_column(
         # before them, contaminating the body with "see page 2, 4, 7..."
         # listings. We log them but don't emit a node — they have no
         # useful content for downstream consumers.
-        if role == BlockRole.index:
+        if role == BlockRole.toc_index:
             logger.debug(
                 "Dropping index block %s: %s", block.block_id, block.text[:60]
             )


### PR DESCRIPTION
## 변경사항

검토 중 발견한 2개 latent type-bug 을 fix. 현재 런타임에 터지는 버그는 아니지만 조건이 맞으면 크래시할 수 있는 footgun.

### 수정 (2 commits)

| Commit | 파일 | 내용 |
|---|---|---|
| `2d98a8a` | `src/paperslice/segmenter.py` | `_ArticleBuilder` 의 list 필드를 `field(default_factory=list)` 로. `None` 기본값 + `__post_init__` 치환 패턴 제거. 누군가 `__post_init__` 우회하는 경로 생기면 `None.append()` 크래시 가능성 제거. |
| `232c658` | `src/paperslice/classifier.py`, `src/paperslice/segmenter.py` | `BlockRole.index` → `BlockRole.toc_index` rename. `BlockRole` 이 str 상속이라 멤버 이름 `index` 가 `str.index()` 메서드 shadowing 하던 footgun 제거. value 는 `"index"` 그대로라 JSON 직렬화/API 호환성 보존. |

### 사용처 검증

- **`BlockRole.index`**: 호출 사이트 2곳 (classifier.py:204 assignment, segmenter.py:549 비교) 모두 rename. `BlockRole.name` / `BlockRole("index")` 문자열 구성 패턴은 grep 결과 없음 → 외부 API/JSON 호환성 영향 없음.
- **`_ArticleBuilder`**: 호출 사이트 하나뿐 (`segmenter.py:529 _ArticleBuilder(kind=kind)`), `kind` 만 넘기고 나머지 기본값 사용. 동작 변화 없음.

### 테스트

- [x] `ruff check .` 통과
- [x] `pytest` — 45/45 pass
- [x] `mypy src/paperslice/segmenter.py src/paperslice/classifier.py` — **no issues** (이전 5건 에러 소거)
- [x] `mypy src/paperslice` 전체 — 19 → 14 에러 (나머지 14건은 columns.py mypy false positive 12 + fitz stub 1 + 기타 1; 이번 PR 스코프 밖)

### 왜 이번 PR 에만 이것만 있나

점검하면서 발견된 7개 중 High 2 개만 고르고 나머지는 TODOS.md 따로:
- [MEDIUM] columns.py false positive 12건 → 다음 PR 에서 `assert bbox is not None` 로 narrowing
- [MEDIUM] `pdf_chunker.py:48` fitz 타입 스텁 부재 → pyproject `[[tool.mypy.overrides]]` 추가
- [LOW] `Dockerfile.gpu` dangling reference, compose 에 `BUILD_OFFLINE_TOLERANT` 미노출 등

## Breaking change

- [ ] Yes
- [x] No (내부 python 이름만 변경, value/JSON 무변경)
